### PR TITLE
Centered description and Underlined footer links

### DIFF
--- a/css/footer.css
+++ b/css/footer.css
@@ -12,6 +12,10 @@ footer p {
   padding: 1.6rem;
 }
 
+footer p a {
+  text-decoration: underline;
+}
+
 .copyright {
   background-color: var(--footer-bg);
 }

--- a/css/header.css
+++ b/css/header.css
@@ -52,6 +52,7 @@ header .container {
   font-weight: 900;
   font-size: 2.75rem;
   line-height: 1.25;
+  margin: auto;
 }
 
 #intro .card {


### PR DESCRIPTION
I centered the description text (h3) as also mentioned in [this comment](https://github.com/MrAshwin2142/The-Wall-of-Projects/pull/110#issuecomment-1878321906)

![Centered text](https://github.com/MrAshwin2142/The-Wall-of-Projects/assets/84842443/5f78db03-cbfd-484f-8b49-5e50f0280beb)


Also I made the footer links underlined to make them stand out (as they were not standing out as links)
![Underlined links](https://github.com/MrAshwin2142/The-Wall-of-Projects/assets/84842443/886e9a74-32a0-4c70-b71c-5a2c65f8056a)
