### PR TITLE
fix: Change The CopyRight Year 2023 to 2025 #12

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Ashwin Dhangar
+Copyright (c) 2025 Ashwin Dhangar
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/index.html
+++ b/index.html
@@ -244,7 +244,7 @@
         /></a>
       </p>
       <div class="copyright">
-        <p>&copy; <s>2023 The Wall Of Projects</s></p>
+        <p>&copy; <s>2025 The Wall Of Projects</s></p>
       </div>
     </footer>
 


### PR DESCRIPTION
Fix: Update Copyright Year

Summary
This PR updates the copyright year from 2023 to 2025 across the project.

Changes Made

Replaced all occurrences of 2023 with 2025 in copyright text.

Ensured consistency across footer and metadata files.

Why This Change?
Keeping the copyright year updated helps maintain

Issue Linked
Fixes #12